### PR TITLE
Add PyPI publish workflow; rename package to bc7enc

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,7 @@ name: Build Wheels
 on:
   push:
     branches: [ "main", "ci" ]
+    tags: [ "v*" ]
   pull_request:
     branches: [ "main", "ci"]
 jobs:
@@ -58,3 +59,30 @@ jobs:
           name: wheels
           pattern: cibw-wheels-*
           delete-merged: true
+
+  publish:
+    name: Publish to PyPI
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: [tests, merge_wheels]
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write  # required for PyPI trusted publishing (OIDC); no API token needed
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Verify tag matches pyproject.toml version
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          PKG_VERSION="$(grep -m1 '^version = ' pyproject.toml | sed -E 's/version = "(.*)"/\1/')"
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "::error::Tag $GITHUB_REF_NAME (version $TAG_VERSION) does not match pyproject.toml version $PKG_VERSION"
+            exit 1
+          fi
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: wheels
+          path: dist
+
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,7 @@ jobs:
 
   build_wheels:
     name: Build wheels on ${{ matrix.os }}
+    needs: tests
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.5)
-project(pybc7)
+project(bc7enc)
 
 
 set (BC7ENC_SRC_LIST
@@ -13,4 +13,4 @@ set (BC7ENC_SRC_LIST
 	)
 
 set(CMAKE_SHARED_LIBRARY_PREFIX "")
-add_library(pybc7 SHARED ${BC7ENC_SRC_LIST})
+add_library(bc7enc SHARED ${BC7ENC_SRC_LIST})

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# pybc7
+# bc7enc-py
 
 ⚠️
 This is a work in progress
@@ -35,7 +35,7 @@ The API for now focus on cases for unpacking the dds data where no header might 
 
 ```
 from PIL import Image  # Optional
-from pybc7 import unpack_dds
+from bc7enc import unpack_dds
 
 # Decoding
 
@@ -79,7 +79,7 @@ pixels = unpack_dds(f, 1024, 1024, "DXT5", 128, unswizzle="agnm")  # or "rxgb"
 
 ```
 from PIL import Image
-from pybc7 import pack_dds
+from bc7enc import pack_dds
 
 # Encoding
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ where = ["src"]
 
 [tool.setuptools.package-data]
 # Compiled in setup.py
-pybc7 = ["pybc7.so", "pybc7.dll"]
+bc7enc = ["bc7enc.so", "bc7enc.dll"]
 
 [tool.cibuildwheel]
 build = "cp310-*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "pybc7"
+name = "bc7enc-py"
 version = "0.1.0"
 description = "Python bindings for bc7enc_rdo, state of the art RDO BC1-7 GPU texture encoders"
 readme = "README.md"

--- a/setup.py
+++ b/setup.py
@@ -19,9 +19,9 @@ class bdist_wheel(_bdist_wheel):
 
         base_dir = os.getcwd()
         try:
-            shutil.move(os.path.join(base_dir, "pybc7.so"), "src/pybc7/pybc7.so")
+            shutil.move(os.path.join(base_dir, "bc7enc.so"), "src/bc7enc/bc7enc.so")
         except FileNotFoundError:
-            shutil.move(os.path.join(base_dir, "Release", "pybc7.dll"), "src/pybc7/pybc7.dll")
+            shutil.move(os.path.join(base_dir, "Release", "bc7enc.dll"), "src/bc7enc/bc7enc.dll")
 
         super().run()
 

--- a/src/bc7enc/__init__.py
+++ b/src/bc7enc/__init__.py
@@ -10,9 +10,9 @@ this_dir = os.path.dirname(__file__)
 
 if not bc7:
     try:
-        bc7 = ctypes.cdll.LoadLibrary(os.path.join(this_dir, 'pybc7.so'))
+        bc7 = ctypes.cdll.LoadLibrary(os.path.join(this_dir, 'bc7enc.so'))
     except OSError:
-        bc7 = ctypes.cdll.LoadLibrary(os.path.join(this_dir, 'pybc7.dll'))
+        bc7 = ctypes.cdll.LoadLibrary(os.path.join(this_dir, 'bc7enc.dll'))
     bc7.init(0)
     bc7.bc7_init()
 

--- a/tests/data/README.md
+++ b/tests/data/README.md
@@ -59,7 +59,7 @@ BC7 has no legacy FourCC of its own.
 ```python
 import struct
 from PIL import Image
-from pybc7 import pack_dds
+from bc7enc import pack_dds
 
 def make_dds_dx10_header(width, height, dxgi_format):
     magic = b"DDS "

--- a/tests/test_decode.py
+++ b/tests/test_decode.py
@@ -5,7 +5,7 @@ import numpy as np
 from PIL import Image
 from tests.conftest import DATA_DIR, DATA_OUT_DIR, psnr
 
-from pybc7 import pack_dds, unpack_dds
+from bc7enc import pack_dds, unpack_dds
 
 
 def test_decoding(dds_sample):

--- a/tests/test_encode.py
+++ b/tests/test_encode.py
@@ -5,7 +5,7 @@ import numpy as np
 from PIL import Image
 from tests.conftest import DATA_OUT_DIR, psnr
 
-from pybc7 import pack_dds, unpack_dds
+from bc7enc import pack_dds, unpack_dds
 
 
 def test_encoding(encode_sample):


### PR DESCRIPTION
## Summary
- Adds a `publish` job to `.github/workflows/build.yml`, gated to tag pushes matching `v*`. It runs after the existing tests + wheel-build matrix, verifies the pushed tag matches `pyproject.toml`'s version (fails the job otherwise), and uploads the merged wheels artifact to PyPI via trusted publishing.
- Renames the package from `pybc7` to `bc7enc` (PyPI distribution name `bc7enc-py`). The original name `pybc7` was rejected by PyPI as a typosquatting risk against the existing `pybc` package.