### PR TITLE
Add optional mipmap generation (pack_dds mipmaps=)

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,3 +102,27 @@ bc7enc_rdo only exposes single 4x4-block encoders (`bc7enc_compress_block`,
 DXT3/DXT5 encoder to call directly. `pack_dds` gets this by looping blocks in
 `wrapper.cpp` (our own file) and calling whichever single-block encoder the
 format needs, without modifying the bc7enc_rdo submodule itself.
+
+**Mipmaps:** bc7enc_rdo has no concept of mip levels either — it's a pure
+block compressor, same posture as Microsoft's
+[DirectXTex](https://github.com/microsoft/DirectXTex) (whose `GenerateMipMaps`
+and `CompressEx` are entirely separate: one resamples an uncompressed image,
+the other loops over an already-built chain compressing each level
+independently). `pack_dds` follows the same split — it's opt-in and doesn't
+change the function's return type:
+
+```
+blocks = pack_dds(im.tobytes(), im.width, im.height, "BC7", mipmaps=True)
+# blocks is still plain bytes: every mip level's block data concatenated in
+# order (base level first), same "no DDS header" contract as the single-
+# level case. mipmaps=<int> caps the chain at that many levels instead of
+# going all the way down to 1x1.
+```
+
+Level dimensions follow the standard mip halving rule (`dim > 1 ? dim // 2 : 1`,
+independent per axis). Resampling uses a 2x2 box filter when both base
+dimensions are powers of 2 (exact averaging, since every level then halves
+cleanly), and falls back to a general bilinear resize otherwise — mirroring
+DirectXTex's own fallback rule (`TEX_FILTER_BOX` only for power-of-2 input,
+`TEX_FILTER_LINEAR` otherwise). See `generate_mip_chain` and wrapper.cpp's
+`downsample_box`/`downsample_bilinear`.

--- a/src/bc7enc/__init__.py
+++ b/src/bc7enc/__init__.py
@@ -219,12 +219,7 @@ PACK_DDS_FORMATS = {
 }
 
 
-def pack_dds(rgba, width, height, dds_format, **kwargs):
-    if dds_format not in PACK_DDS_FORMATS:
-        raise TypeError(f"Invalid DDS format: {dds_format}")
-
-    size_block, pack_func = PACK_DDS_FORMATS[dds_format]
-
+def _pack_dds_single_level(rgba, width, height, pack_func, size_block, **kwargs):
     # Block storage rounds up: width/height need not be multiples of 4 (nor
     # powers of 2) per the DDS/BC spec; compress_image_blocks() in wrapper.cpp
     # clamps edge-block reads accordingly.
@@ -241,6 +236,68 @@ def pack_dds(rgba, width, height, dds_format, **kwargs):
     pack_func(rgba_ptr, width, height, ctypes.byref(blocks), **kwargs)
 
     return bytes(blocks)
+
+
+def _is_pow2(n):
+    return n > 0 and (n & (n - 1)) == 0
+
+
+def generate_mip_chain(rgba, width, height, max_levels=None):
+    """
+    Generates a mip chain from a base RGBA image: [(width, height,
+    rgba_bytes), ...] starting with the (unchanged) base level down to
+    1x1, or max_levels total if given. Each level's dimensions follow the
+    standard mip halving rule (dim > 1 ? dim // 2 : 1), independent per
+    axis - this is unrelated to the ceil-based block-count rounding
+    pack_dds/unpack_dds do per level.
+
+    bc7enc_rdo has no mip-generation of its own (it's a pure block
+    compressor - see wrapper.cpp's compress_image_blocks); this uses a 2x2
+    box filter when both base dimensions are powers of 2 (exact averaging,
+    since every level then halves cleanly), and falls back to a general
+    bilinear resize otherwise, mirroring DirectXTex's own fallback rule
+    (see wrapper.cpp's downsample_box/downsample_bilinear).
+    """
+    downsample = bc7.downsample_box if (_is_pow2(width) and _is_pow2(height)) else bc7.downsample_bilinear
+
+    cur_width, cur_height = width, height
+    cur_bytes = bytes(rgba)
+    levels = [(cur_width, cur_height, cur_bytes)]
+
+    while cur_width > 1 or cur_height > 1:
+        if max_levels is not None and len(levels) >= max_levels:
+            break
+
+        next_width = cur_width // 2 if cur_width > 1 else 1
+        next_height = cur_height // 2 if cur_height > 1 else 1
+
+        cur_buf = ctypes.create_string_buffer(cur_bytes, len(cur_bytes))
+        next_buf = ctypes.create_string_buffer(next_width * next_height * 4)
+        downsample(ctypes.byref(cur_buf), cur_width, cur_height, ctypes.byref(next_buf), next_width, next_height)
+
+        cur_width, cur_height = next_width, next_height
+        cur_bytes = bytes(next_buf)
+        levels.append((cur_width, cur_height, cur_bytes))
+
+    return levels
+
+
+def pack_dds(rgba, width, height, dds_format, mipmaps=False, **kwargs):
+    if dds_format not in PACK_DDS_FORMATS:
+        raise TypeError(f"Invalid DDS format: {dds_format}")
+
+    size_block, pack_func = PACK_DDS_FORMATS[dds_format]
+
+    if not mipmaps:
+        return _pack_dds_single_level(rgba, width, height, pack_func, size_block, **kwargs)
+
+    max_levels = mipmaps if isinstance(mipmaps, int) and mipmaps is not True else None
+    levels = generate_mip_chain(rgba, width, height, max_levels=max_levels)
+
+    return b"".join(
+        _pack_dds_single_level(level_rgba, level_width, level_height, pack_func, size_block, **kwargs)
+        for level_width, level_height, level_rgba in levels
+    )
 
 
 # See wrapper.cpp's unswizzle_agnm/unswizzle_rxgb for the algorithm/rationale

--- a/tests/test_mipmaps.py
+++ b/tests/test_mipmaps.py
@@ -1,0 +1,117 @@
+import ctypes
+import io
+
+import numpy as np
+import pytest
+from PIL import Image
+from tests.conftest import DATA_DIR, psnr
+
+from bc7enc import bc7, generate_mip_chain, pack_dds, unpack_dds
+
+
+def _downsample(func, src_bytes, src_width, src_height, dst_width, dst_height):
+    src_buf = ctypes.create_string_buffer(src_bytes, len(src_bytes))
+    dst_buf = ctypes.create_string_buffer(dst_width * dst_height * 4)
+    func(ctypes.byref(src_buf), src_width, src_height, ctypes.byref(dst_buf), dst_width, dst_height)
+    return bytes(dst_buf)
+
+
+def test_downsample_box():
+    # 4x4 checkerboard: red/green alternating both directions. Each 2x2
+    # destination cell covers exactly 2 red + 2 green source pixels, so the
+    # exact expected average is (128, 128, 0, 255) - not an approximation.
+    red, green = bytes([255, 0, 0, 255]), bytes([0, 255, 0, 255])
+    src = b"".join(red if (x + y) % 2 == 0 else green for y in range(4) for x in range(4))
+
+    out = _downsample(bc7.downsample_box, src, 4, 4, 2, 2)
+    expected_pixel = bytes([128, 128, 0, 255])
+    assert out == expected_pixel * 4
+
+    # Degenerate case: one axis already at 1 (can't halve further). Box
+    # filter must collapse to sampling that single row/column twice rather
+    # than reading out of bounds.
+    pixel = bytes([10, 20, 30, 255])
+    src_1x4 = pixel * 4
+    out = _downsample(bc7.downsample_box, src_1x4, 1, 4, 1, 2)
+    assert out == pixel * 2
+
+
+def test_downsample_bilinear():
+    # 2x1 -> 1x1: destination pixel center maps exactly to the midpoint
+    # between the two source pixels.
+    src = bytes([0, 0, 0, 255]) + bytes([100, 200, 50, 255])
+    out = _downsample(bc7.downsample_bilinear, src, 2, 1, 1, 1)
+    assert out == bytes([50, 100, 25, 255])
+
+    # 3x1 -> 2x1: a non-2x ratio, exercising the general (non-power-of-2
+    # fallback) resize path with hand-computed expected weights.
+    src = bytes([0, 0, 0, 255]) + bytes([100, 100, 100, 255]) + bytes([200, 200, 200, 255])
+    out = _downsample(bc7.downsample_bilinear, src, 3, 1, 2, 1)
+    assert out == bytes([25, 25, 25, 255]) + bytes([175, 175, 175, 255])
+
+
+def test_generate_mip_chain_filter_selection_and_dimensions():
+    # Power-of-2 base -> box filter, clean halving down to 1x1.
+    levels = generate_mip_chain(b"\x00" * (256 * 256 * 4), 256, 256)
+    assert [(w, h) for w, h, _ in levels] == [
+        (256, 256), (128, 128), (64, 64), (32, 32), (16, 16), (8, 8), (4, 4), (2, 2), (1, 1),
+    ]
+
+    # Non-power-of-2 base -> bilinear fallback, floor-halving per axis.
+    levels = generate_mip_chain(b"\x00" * (250 * 250 * 4), 250, 250)
+    assert [(w, h) for w, h, _ in levels] == [
+        (250, 250), (125, 125), (62, 62), (31, 31), (15, 15), (7, 7), (3, 3), (1, 1),
+    ]
+
+    # max_levels caps the chain without changing earlier levels' dimensions.
+    capped = generate_mip_chain(b"\x00" * (256 * 256 * 4), 256, 256, max_levels=3)
+    assert [(w, h) for w, h, _ in capped] == [(256, 256), (128, 128), (64, 64)]
+
+
+def test_pack_dds_mipmaps_default_unchanged():
+    original = Image.open(f"{DATA_DIR}/bluemarble.png").convert("RGBA")
+    rgba = original.tobytes()
+
+    single = pack_dds(rgba, original.width, original.height, "BC7")
+    assert pack_dds(rgba, original.width, original.height, "BC7", mipmaps=False) == single
+    assert pack_dds(rgba, original.width, original.height, "BC7") == single  # no mipmaps kwarg at all
+
+
+@pytest.mark.parametrize("size", [(256, 256), (250, 250)], ids=["pow2", "non_pow2"])
+def test_pack_dds_mipmaps_roundtrip(size):
+    # No new fixture needed: derive both the power-of-2 and non-power-of-2
+    # base images from the existing bluemarble.png fixture (same approach
+    # as the non-multiple-of-4 regression test in test_decode.py).
+    original = Image.open(f"{DATA_DIR}/bluemarble.png").convert("RGBA").resize(size)
+    width, height = size
+
+    blocks = pack_dds(original.tobytes(), width, height, "BC7", mipmaps=True)
+
+    w, h = width, height
+    offset = 0
+    level = 0
+    while True:
+        size_bytes = ((w + 3) // 4) * ((h + 3) // 4) * 16
+        level_blocks = blocks[offset:offset + size_bytes]
+
+        fake_header = b"\x00" * 128
+        pixels = unpack_dds(io.BytesIO(fake_header + level_blocks), w, h, "BC7", len(fake_header))
+        decoded = np.frombuffer(bytes(pixels), dtype=np.uint8).reshape(h, w, 4)
+
+        reference = np.array(original.resize((w, h), Image.LANCZOS))
+        score = psnr(reference, decoded)
+        # Loose floor: box/bilinear resampling vs. an independent LANCZOS
+        # reference naturally diverge more at very small levels (a handful
+        # of pixels, extreme downsampling ratio), on top of BC7's own
+        # quantization - this just needs to catch a broken chain, not match
+        # LANCZOS exactly.
+        assert score >= 10.0, f"level {level} ({w}x{h}): PSNR={score:.2f}dB"
+
+        offset += size_bytes
+        level += 1
+        if w == 1 and h == 1:
+            break
+        w = w // 2 if w > 1 else 1
+        h = h // 2 if h > 1 else 1
+
+    assert offset == len(blocks)

--- a/wrapper.cpp
+++ b/wrapper.cpp
@@ -97,6 +97,75 @@ extern "C" LIB_EXPORT void unswizzle_rxgb(uint8_t *rgba, int width, int height) 
 }
 
 
+// Resizes src (src_width x src_height RGBA) into caller-allocated dst
+// (dst_width x dst_height RGBA) via a 2x2 box average. Only valid when
+// dst dims are max(1, src_dim>>1) on each axis (i.e. one mip-chain step in
+// a power-of-2 base image, per the standard mip halving rule) - the "axis
+// already at 1" case is handled the same way DirectXTex's
+// Generate2DMipsBoxFilter does, by resampling the same row/column twice
+// instead of requiring square-only input.
+extern "C" LIB_EXPORT void downsample_box(const uint8_t *src, int src_width, int src_height,
+                                           uint8_t *dst, int dst_width, int dst_height) {
+    for (int dy = 0; dy < dst_height; ++dy) {
+        int sy0 = (src_height > 1) ? dy * 2 : 0;
+        int sy1 = (src_height > 1) ? sy0 + 1 : sy0;
+        for (int dx = 0; dx < dst_width; ++dx) {
+            int sx0 = (src_width > 1) ? dx * 2 : 0;
+            int sx1 = (src_width > 1) ? sx0 + 1 : sx0;
+
+            const uint8_t *p00 = src + 4 * (sy0 * src_width + sx0);
+            const uint8_t *p01 = src + 4 * (sy0 * src_width + sx1);
+            const uint8_t *p10 = src + 4 * (sy1 * src_width + sx0);
+            const uint8_t *p11 = src + 4 * (sy1 * src_width + sx1);
+            uint8_t *out = dst + 4 * (dy * dst_width + dx);
+
+            for (int c = 0; c < 4; ++c)
+                out[c] = (uint8_t)((p00[c] + p01[c] + p10[c] + p11[c] + 2) / 4);
+        }
+    }
+}
+
+// General bilinear resize of src (src_width x src_height RGBA) into
+// caller-allocated dst (dst_width x dst_height RGBA), for arbitrary
+// dst dims relative to src (not just clean 2x downsampling). Fallback for
+// mip generation on non-power-of-2 base images, matching how DirectXTex
+// falls back to TEX_FILTER_LINEAR in that case.
+extern "C" LIB_EXPORT void downsample_bilinear(const uint8_t *src, int src_width, int src_height,
+                                                uint8_t *dst, int dst_width, int dst_height) {
+    double x_ratio = (double)src_width / (double)dst_width;
+    double y_ratio = (double)src_height / (double)dst_height;
+
+    for (int dy = 0; dy < dst_height; ++dy) {
+        double sy = (dy + 0.5) * y_ratio - 0.5;
+        int sy0 = (int)std::floor(sy);
+        double fy = sy - sy0;
+        int sy0c = sy0 < 0 ? 0 : (sy0 >= src_height ? src_height - 1 : sy0);
+        int sy1c = (sy0 + 1) < 0 ? 0 : ((sy0 + 1) >= src_height ? src_height - 1 : (sy0 + 1));
+
+        for (int dx = 0; dx < dst_width; ++dx) {
+            double sx = (dx + 0.5) * x_ratio - 0.5;
+            int sx0 = (int)std::floor(sx);
+            double fx = sx - sx0;
+            int sx0c = sx0 < 0 ? 0 : (sx0 >= src_width ? src_width - 1 : sx0);
+            int sx1c = (sx0 + 1) < 0 ? 0 : ((sx0 + 1) >= src_width ? src_width - 1 : (sx0 + 1));
+
+            const uint8_t *p00 = src + 4 * (sy0c * src_width + sx0c);
+            const uint8_t *p01 = src + 4 * (sy0c * src_width + sx1c);
+            const uint8_t *p10 = src + 4 * (sy1c * src_width + sx0c);
+            const uint8_t *p11 = src + 4 * (sy1c * src_width + sx1c);
+            uint8_t *out = dst + 4 * (dy * dst_width + dx);
+
+            for (int c = 0; c < 4; ++c) {
+                double top = p00[c] * (1.0 - fx) + p01[c] * fx;
+                double bot = p10[c] * (1.0 - fx) + p11[c] * fx;
+                double val = top * (1.0 - fy) + bot * fy;
+                out[c] = (uint8_t)(val + 0.5);
+            }
+        }
+    }
+}
+
+
 extern "C" LIB_EXPORT bool pack_bc7_block(void *pBlock, const void *pPixelsRGBA, const bc7enc_compress_block_params *pComp_params) {
     return bc7enc_compress_block(pBlock, pPixelsRGBA, pComp_params);
 }


### PR DESCRIPTION
pack_dds gets an opt-in `mipmaps=` parameter, resampling in C++
(box filter for power-of-2 dimensions, bilinear otherwise) before
encoding each level. Default behavior/return type unchanged.